### PR TITLE
feat(부서): Dto, Mapper 추가

### DIFF
--- a/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
+++ b/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
@@ -1,7 +1,10 @@
 package com.codeit.hrbank.department.controller;
 
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/departments")
 public class DepartmentController {
+
 }

--- a/src/main/java/com/codeit/hrbank/department/dto/request/DepartmentCreateRequest.java
+++ b/src/main/java/com/codeit/hrbank/department/dto/request/DepartmentCreateRequest.java
@@ -1,0 +1,10 @@
+package com.codeit.hrbank.department.dto.request;
+
+import java.time.LocalDate;
+
+public record DepartmentCreateRequest(
+        String name,
+        String description,
+        LocalDate establishedDate
+) {
+}

--- a/src/main/java/com/codeit/hrbank/department/dto/request/DepartmentUpdateRequest.java
+++ b/src/main/java/com/codeit/hrbank/department/dto/request/DepartmentUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.codeit.hrbank.department.dto.request;
+
+import java.time.LocalDate;
+
+public record DepartmentUpdateRequest(
+        String name,
+        String description,
+        LocalDate establishedDate
+) {
+}

--- a/src/main/java/com/codeit/hrbank/department/dto/response/DepartmentDto.java
+++ b/src/main/java/com/codeit/hrbank/department/dto/response/DepartmentDto.java
@@ -1,0 +1,12 @@
+package com.codeit.hrbank.department.dto.response;
+
+import java.time.LocalDate;
+
+public record DepartmentDto(
+        Long id,
+        String name,
+        String description,
+        LocalDate establishedDate,
+        Long employeeCount
+) {
+}

--- a/src/main/java/com/codeit/hrbank/department/mapper/DepartmentMapper.java
+++ b/src/main/java/com/codeit/hrbank/department/mapper/DepartmentMapper.java
@@ -1,0 +1,13 @@
+package com.codeit.hrbank.department.mapper;
+
+import com.codeit.hrbank.department.dto.request.DepartmentCreateRequest;
+import com.codeit.hrbank.department.dto.response.DepartmentDto;
+import com.codeit.hrbank.department.entity.Department;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface DepartmentMapper {
+
+    Department toEntity (DepartmentCreateRequest departmentCreateRequest);
+    DepartmentDto toDto (Department department, Long employeeCount);
+}


### PR DESCRIPTION
## 📌 PR 내용 요약
- DepartmentCreateRequest, DepartmentUpdateRequest, DepartmentDto를 추가하였습니다.
- DepartmentMapper를 MapStruct를 이용하여 구현하였습니다.

## 🔗 관련 이슈
- Closes #37 

## 🙋 리뷰어에게 요청사항 (선택)
- DepartmentEntity가 아직 PR 반영되지 않아 반영 이후 Mapper의 수정이 필요할 수 있습니다.
- DepartmentMapper의 `toDto()` 부분에서, Department Entity에는 employeeCount가 없어서 매개변수로 받아서 처리하도록 하였습니다. 