### PR TITLE
feat(부서): 부서 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
+++ b/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
@@ -1,17 +1,18 @@
 package com.codeit.hrbank.department.controller;
 
-import com.codeit.hrbank.base.dto.PageResponse;
-import com.codeit.hrbank.department.dto.DepartmentProjection;
 import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
 import com.codeit.hrbank.department.dto.response.CursorPageResponseDepartmentDto;
 import com.codeit.hrbank.department.dto.response.DepartmentDto;
+import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.mapper.DepartmentMapper;
 import com.codeit.hrbank.department.service.DepartmentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
@@ -22,15 +23,28 @@ public class DepartmentController {
     private final DepartmentMapper departmentMapper;
 
     @GetMapping
-    public ResponseEntity<CursorPageResponseDepartmentDto<DepartmentDto>> getAll(@ModelAttribute("departmentGetAllRequest") DepartmentGetAllRequest departmentGetAllRequest) {
-        List<DepartmentProjection> departmentProjections = departmentService.getAllDepartments();
-        List<DepartmentDto> departmentDtos = departmentProjections.stream()
-                .map(departmentProjection -> departmentMapper.toDto(
-                        departmentProjection.getDepartment(),
-                        departmentProjection.getEmployeeCount()
-                ))
-                .toList();
+    public ResponseEntity<?> getAll(@ModelAttribute("departmentGetAllRequest") DepartmentGetAllRequest departmentGetAllRequest) {
+        Page<Department> departments = departmentService.getAllDepartments(departmentGetAllRequest);
+        if(!departments.hasContent() || departments.getContent().isEmpty()) {
+            return ResponseEntity.ok(CursorPageResponseDepartmentDto.from(Page.empty(), null, null));
+        }
 
-        return ResponseEntity.ok(departmentDtos);
+        Long idAfter = departments.getContent().get(departments.getContent().size() - 1).getId();
+
+        String cursor = null;
+        switch(departmentGetAllRequest.sortField()) {
+            case "name" -> {
+                cursor = departments.getContent().get(departments.getContent().size() - 1).getName();
+            }
+            case "establishedDate" -> {
+                cursor = departments.getContent().get(departments.getContent().size() - 1).getEstablishedDate().toString();
+            }
+        }
+
+        Page<DepartmentDto> departmentDtos = departments
+                .map(department -> departmentMapper.toDto(department, departmentService.getEmployeeCountByDepartmentId(department.getId())));
+
+        CursorPageResponseDepartmentDto response = CursorPageResponseDepartmentDto.from(departmentDtos, idAfter, cursor);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/codeit/hrbank/department/dto/DepartmentProjection.java
+++ b/src/main/java/com/codeit/hrbank/department/dto/DepartmentProjection.java
@@ -1,8 +1,0 @@
-package com.codeit.hrbank.department.dto;
-
-import com.codeit.hrbank.department.entity.Department;
-
-public interface DepartmentProjection {
-    Department getDepartment();
-    Long getEmployeeCount();
-}

--- a/src/main/java/com/codeit/hrbank/department/entity/Department.java
+++ b/src/main/java/com/codeit/hrbank/department/entity/Department.java
@@ -1,17 +1,14 @@
 package com.codeit.hrbank.department.entity;
 
 import com.codeit.hrbank.base_entity.BaseUpdatableEntity;
-import com.codeit.hrbank.employee.entity.Employee;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @Setter
@@ -27,7 +24,4 @@ public class Department extends BaseUpdatableEntity {
 
     @Column(nullable = false)
     private LocalDate establishedDate;
-
-    @OneToMany(mappedBy = "department")
-    private List<Employee> employees;
 }

--- a/src/main/java/com/codeit/hrbank/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/codeit/hrbank/department/repository/DepartmentRepository.java
@@ -1,20 +1,9 @@
 package com.codeit.hrbank.department.repository;
 
-import com.codeit.hrbank.department.dto.DepartmentProjection;
 import com.codeit.hrbank.department.entity.Department;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 
 public interface DepartmentRepository extends JpaRepository<Department, Long>, JpaSpecificationExecutor<Department> {
-
-    @Query("""
-            SELECT d AS department, COUNT(e.id) AS employeeCount
-            FROM Department d
-            LEFT JOIN d.employees e
-            GROUP BY d
-            """)
-    List<DepartmentProjection> findAllWithEmployeeCount();
 }

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -18,13 +18,13 @@ import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class BasicDepartmentService implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
     //
     private final EmployeeRepository employeeRepository;
 
+    @Transactional(readOnly = true)
     @Override
     public Page<Department> getAllDepartments(DepartmentGetAllRequest departmentGetAllRequest) {
         // 검색 필드, 정렬 방향 초기화

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -4,6 +4,7 @@ import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
 import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.repository.DepartmentRepository;
 import com.codeit.hrbank.department.specification.DepartmentSpecification;
+import com.codeit.hrbank.employee.repository.EmployeeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,11 +22,13 @@ import java.time.LocalDate;
 public class BasicDepartmentService implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
+    //
+    private final EmployeeRepository employeeRepository;
 
     @Override
     public Page<Department> getAllDepartments(DepartmentGetAllRequest departmentGetAllRequest) {
         // 검색 필드, 정렬 방향 초기화
-        String sortField = departmentGetAllRequest.sortField() == null ? "name" : departmentGetAllRequest.sortField();
+        String sortField = departmentGetAllRequest.sortField() == null || departmentGetAllRequest.sortField().isEmpty() ? "name" : departmentGetAllRequest.sortField();
         String sortDirection = departmentGetAllRequest.sortDirection() == null ? "asc" : departmentGetAllRequest.sortDirection();
 
         Specification<Department> spec = Specification.unrestricted();
@@ -80,5 +83,10 @@ public class BasicDepartmentService implements DepartmentService {
             default -> pageable = PageRequest.ofSize(pageSize).withSort(Sort.by(sortField).ascending());
         }
         return departmentRepository.findAll(spec, pageable);
+    }
+
+    @Override
+    public Long getEmployeeCountByDepartmentId(Long departmentId) {
+        return employeeRepository.countByDepartmentId(departmentId);
     }
 }

--- a/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
@@ -1,10 +1,11 @@
 package com.codeit.hrbank.department.service;
 
-import com.codeit.hrbank.department.dto.DepartmentProjection;
 import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
-
-import java.util.List;
+import com.codeit.hrbank.department.entity.Department;
+import org.springframework.data.domain.Page;
 
 public interface DepartmentService {
-    List<DepartmentProjection> getAllDepartments(DepartmentGetAllRequest pageRequest);
+    Page<Department> getAllDepartments(DepartmentGetAllRequest pageRequest);
+
+    Long getEmployeeCountByDepartmentId(Long departmentId);
 }

--- a/src/main/java/com/codeit/hrbank/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/codeit/hrbank/employee/repository/EmployeeRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long>, JpaSpecificationExecutor<Employee> {
     boolean existsByEmail(String email);
+
+    Long countByDepartmentId(Long departmentId);
 }

--- a/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
+++ b/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
@@ -3,12 +3,16 @@ package com.codeit.hrbank.exception;
 import lombok.Getter;
 
 public enum ExceptionCode {
-    DEPARTMENT_HAS_EMPLOYEE_CANNOT_DELETE(400, "소속 직원이 있는 부서는 삭제할 수 없습니다.", "details"),
-    DEPARTMENT_ID_IS_NOT_FOUND(400, "잘못된 요청입니다.", "details"),
+    DEPARTMENT_HAS_EMPLOYEE_CANNOT_DELETE(400, "잘못된 요청입니다.", "소속 직원이 있는 부서는 삭제할 수 없습니다."),
+    DEPARTMENT_ID_IS_NOT_FOUND(404, "잘못된 요청입니다.", "해당 부서를 찾을 수 없습니다."),
     STORED_FILE_NOT_FOUND(404,"잘못된 요청입니다.","해당 이미지를 찾을 수 없습니다."),
-    EMAIL_ALREADY_EXISTS(400, "잘못된 요청입니다.", "해당 이메일은 이미 존재합니다."),
-    EMPLOYEE_NOT_FOUND(404, "잘못된 요청입니다.", "해당 직원을 찾을 수 없습니다."),
+    NAME_ALREADY_EXISTS(400, "잘못된 입력입니다.", "해당 이름은 이미 존재합니다."),
+    NAME_CANNOT_BE_NULL(400, "잘못된 입력입니다.", "이름이 비어있거나 null이 될 수 없습니다."),
+    DESCRIPTION_CANNOT_BE_NULL(400, "잘못된 입력입니다.", "설명이 비어있거나 null이 될 수 없습니다."),
+    EMAIL_ALREADY_EXISTS(400,"잘못된 입력입니다.","해당 이메일은 이미 존재합니다."),
+    EMPLOYEE_NOT_FOUND(404,"잘못된 요청입니다.", "해당 직원을 찾을 수 없습니다."),
     STOREDFILE_NOT_FOUND(404, "잘못된 요청입니다.", "해당 파일을 찾을 수 없습니다.");
+
 //    USER_NOT_FOUND(404, "User Not Found"),
 //    EMAIL_OR_USERNAME_ALREADY_EXISTS(400, "User With Email Already Exists"),
 //    CHANNEL_OR_USER_NOT_FOUND(404, "Channel | User With ID Not Found"),


### PR DESCRIPTION
## 📌 PR 내용 요약
- 부서 목록을 조회할 수 있는 기능을 구현했습니다.

- 코드 리뷰 받은 부분 반영하였습니다.
  - 페이지네이션 처리 구현
  - `EmployeeRepository`에 `countByDepartmentId` 메서드 추가
    - `DepartmentDto` 구현 단순화를 위해 `EmployeRepository`에 `employeeCount`를 계산하여 가져오는 `countByDepartmentId` 메서드를 추가하였습니다.
    - `BasicDepartmentService`에 `EmployeeRepository` 의존성을 추가하고, `getEmployeeCountByDepartmentId` 메서드를 추가하였습니다. `DepartmentController`에서 `dto`로 변환할 때 해당 메서드를 이용합니다.
    - `EmployeeRepository`를 이용하므로, 더 이상 `employee`와의 연관 관계가 필요 없는 것 같아 `@OneToMany` 관계를 삭제하였습니다.

- 페이지네이션 처리용 dto인 `DepartmentGetAllRequest`, `CursorPageResponseDepartmentDto`를 추가하였습니다.
-  정렬 방향 및 부분 검색 조건 추가 로직을 `switch`로 구현하였습니다. 
- `@Transactional(readOnly = true)` 속성 추가
- #47 과 동일한 `ExceptionCode`를 추가하였습니다.


## 🔗 관련 이슈
- Closes #18 

## 📚 참고자료 (선택)
- https://chatgpt.com/share/688b322a-a704-8004-95ae-814d88c88149

## 🙋 리뷰어에게 요청사항 (선택)
 - `DepartmentDto`로 변환 할 때 마다 `employeeCount`를 구하는 로직이 필요하기 때문에, 다른 부서 관련 PR보다 더 우선적으로 리뷰, 병합 해주시면 감사하겠습니다.

- 불필요한 파일을 추가한 이력이 있어서 이를 삭제하기 위해 `push --force`를 사용하여 기존의 커밋 이력이 삭제되었습니다.
  - `CursorPageResponseEmployeeDto`를 추가했다가 지웠습니다: `base.dto.PageResponse.java`를 통해 직원 목록 조회 기능이 구현되어 있었습니다. 그러나 최근 `main` 브랜치에서 `base.dto.PageResponse.java`를 삭제하였기 때문에, 해당 부분에 있어 `main`과 `dev`의 싱크가 맞지 않아 컴파일 에러가 발생한 부분을 해결하기 위해 테스트를 위해서 임의로 추가했었으나, 이 PR에는 올라가지 않게 수정하였습니다.
  - `push --force`한 커밋 부분이 `dev`에도 반영이 되어버렸습니다.. 이로 인해 dev를 `pull`하면 `CursorPageResponseEmployeeDto`가 `employee.dto` 내에 추가됩니다.. 죄송합니다.

- `EmployeeRepository`로 `employeeCount`를 계산하게 되어서 `employee`와의 연관 관계를 삭제하긴 했으나, 과연 연관 관계 제거가 필요한 선택이었는지 짚어주시면 감사하겠습니다.

- 리뷰해주신 부분은 #60 으로 반영됩니다.
 