### PR TITLE
feat(부서): 부서 수정 구현 

### DIFF
--- a/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
+++ b/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
@@ -6,6 +6,7 @@ import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.mapper.DepartmentMapper;
 import com.codeit.hrbank.department.service.DepartmentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,8 +17,10 @@ public class DepartmentController {
     private final DepartmentMapper departmentMapper;
 
     @PatchMapping("/{id}")
-    public DepartmentDto update(@PathVariable("id") Long id,
-                                @RequestBody DepartmentUpdateRequest departmentUpdateRequest) {
+    public ResponseEntity<DepartmentDto> update(@PathVariable("id") Long id,
+                                   @RequestBody DepartmentUpdateRequest departmentUpdateRequest) {
         Department department = departmentService.update(departmentUpdateRequest, id);
+        DepartmentDto response = departmentMapper.toDto(department, departmentService.getEmployeeCountByDepartmentId(department.getId()));
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
+++ b/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
@@ -1,10 +1,23 @@
 package com.codeit.hrbank.department.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.codeit.hrbank.department.dto.request.DepartmentUpdateRequest;
+import com.codeit.hrbank.department.dto.response.DepartmentDto;
+import com.codeit.hrbank.department.entity.Department;
+import com.codeit.hrbank.department.mapper.DepartmentMapper;
+import com.codeit.hrbank.department.service.DepartmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/departments")
 public class DepartmentController {
+    private final DepartmentService departmentService;
+    private final DepartmentMapper departmentMapper;
 
+    @PatchMapping("/{id}")
+    public DepartmentDto update(@PathVariable("id") Long id,
+                                @RequestBody DepartmentUpdateRequest departmentUpdateRequest) {
+        Department department = departmentService.update(departmentUpdateRequest, id);
+    }
 }

--- a/src/main/java/com/codeit/hrbank/department/entity/Department.java
+++ b/src/main/java/com/codeit/hrbank/department/entity/Department.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.Instant;
 import java.time.LocalDate;
 
 @Getter
@@ -24,4 +25,26 @@ public class Department extends BaseUpdatableEntity {
 
     @Column(nullable = false)
     private LocalDate establishedDate;
+
+    public void update(String newName, String newDescription, LocalDate newEstablishedDate) {
+        boolean anyValueUpdated = false;
+        if (newName != null && !newName.equals(this.name)) {
+            this.name = newName;
+            anyValueUpdated = true;
+        }
+
+        if (newDescription != null && !newDescription.equals(this.description)) {
+            this.description = newDescription;
+            anyValueUpdated = true;
+        }
+
+        if (newEstablishedDate != null && !newEstablishedDate.equals(this.establishedDate)) {
+            this.establishedDate = newEstablishedDate;
+            anyValueUpdated = true;
+        }
+
+        if (anyValueUpdated) {
+            super.setUpdatedAt(Instant.now());
+        }
+    }
 }

--- a/src/main/java/com/codeit/hrbank/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/codeit/hrbank/department/repository/DepartmentRepository.java
@@ -2,7 +2,8 @@ package com.codeit.hrbank.department.repository;
 
 import com.codeit.hrbank.department.entity.Department;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface DepartmentRepository extends JpaRepository<Department, Long> {
+public interface DepartmentRepository extends JpaRepository<Department, Long>, JpaSpecificationExecutor<Department> {
     boolean existsByName(String name);
 }

--- a/src/main/java/com/codeit/hrbank/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/codeit/hrbank/department/repository/DepartmentRepository.java
@@ -4,4 +4,5 @@ import com.codeit.hrbank.department.entity.Department;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -3,6 +3,7 @@ package com.codeit.hrbank.department.service;
 import com.codeit.hrbank.department.dto.request.DepartmentUpdateRequest;
 import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.repository.DepartmentRepository;
+import com.codeit.hrbank.employee.repository.EmployeeRepository;
 import com.codeit.hrbank.exception.BusinessLogicException;
 import com.codeit.hrbank.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,8 @@ import java.util.Optional;
 public class BasicDepartmentService implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
+    //
+    private final EmployeeRepository employeeRepository;
 
     @Override
     public Department update(DepartmentUpdateRequest departmentUpdateRequest, Long id) {
@@ -25,6 +28,7 @@ public class BasicDepartmentService implements DepartmentService {
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.DEPARTMENT_ID_IS_NOT_FOUND));
 
         // departmentUpdateRequest에 수정할 항목이 비어있으면 기존 값 유지
+
         String newName = Optional.ofNullable(departmentUpdateRequest.name())
                 .filter(name -> !name.isBlank())
                 .orElse(department.getName());
@@ -45,5 +49,9 @@ public class BasicDepartmentService implements DepartmentService {
         return departmentRepository.save(department);
     }
 
+    @Override
+    public Long getEmployeeCountByDepartmentId(Long departmentId) {
+        return employeeRepository.countByDepartmentId(departmentId);
+    }
 
 }

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -1,7 +1,49 @@
 package com.codeit.hrbank.department.service;
 
+import com.codeit.hrbank.department.dto.request.DepartmentUpdateRequest;
+import com.codeit.hrbank.department.entity.Department;
+import com.codeit.hrbank.department.repository.DepartmentRepository;
+import com.codeit.hrbank.exception.BusinessLogicException;
+import com.codeit.hrbank.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class BasicDepartmentService implements DepartmentService {
+
+    private final DepartmentRepository departmentRepository;
+
+    @Override
+    public Department update(DepartmentUpdateRequest departmentUpdateRequest, Long id) {
+        Department department = departmentRepository.findById(id)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.DEPARTMENT_ID_IS_NOT_FOUND));
+
+        // departmentUpdateRequest에 수정할 항목이 비어있으면 기존 값 유지
+        String newName = Optional.ofNullable(departmentUpdateRequest.name())
+                .filter(name -> !name.isBlank())
+                .orElse(department.getName());
+
+        String newDescription = Optional.ofNullable(departmentUpdateRequest.description())
+                .filter(description -> !description.isBlank())
+                .orElse(department.getDescription());
+
+        LocalDate newEstablishedDate = Optional.ofNullable(departmentUpdateRequest.establishedDate())
+                .orElse(department.getEstablishedDate());
+
+        // 이름이 중복되면 안됨
+        if (!newName.equals(department.getName()) && departmentRepository.existsByName(newName)) {
+            throw new BusinessLogicException(ExceptionCode.NAME_ALREADY_EXISTS);
+        }
+
+        department.update(newName, newDescription, newEstablishedDate);
+        return departmentRepository.save(department);
+    }
+
+
 }

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -15,13 +15,13 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class BasicDepartmentService implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
     //
     private final EmployeeRepository employeeRepository;
 
+    @Transactional
     @Override
     public Department update(DepartmentUpdateRequest departmentUpdateRequest, Long id) {
         Department department = departmentRepository.findById(id)

--- a/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
@@ -6,4 +6,6 @@ import com.codeit.hrbank.department.entity.Department;
 public interface DepartmentService {
 
     Department update(DepartmentUpdateRequest departmentUpdateRequest, Long id);
+
+    Long getEmployeeCountByDepartmentId(Long departmentId);
 }

--- a/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
@@ -1,4 +1,9 @@
 package com.codeit.hrbank.department.service;
 
+import com.codeit.hrbank.department.dto.request.DepartmentUpdateRequest;
+import com.codeit.hrbank.department.entity.Department;
+
 public interface DepartmentService {
+
+    Department update(DepartmentUpdateRequest departmentUpdateRequest, Long id);
 }

--- a/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
+++ b/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 public enum ExceptionCode {
     DEPARTMENT_HAS_EMPLOYEE_CANNOT_DELETE(400, "소속 직원이 있는 부서는 삭제할 수 없습니다.", "details"),
     DEPARTMENT_ID_IS_NOT_FOUND(400, "잘못된 요청입니다.", "details"),
+    NAME_ALREADY_EXISTS(400, "잘못된 입력입니다.", "해당 이름은 이미 존재합니다."),
     EMAIL_ALREADY_EXISTS(400,"잘못된 입력입니다.","해당 이메일은 이미 존재합니다."),
     EMPLOYEE_NOT_FOUND(404,"잘못된 요청입니다.", "해당 직원을 찾을 수 없습니다.");
 //    USER_NOT_FOUND(404, "User Not Found"),

--- a/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
+++ b/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
@@ -3,11 +3,14 @@ package com.codeit.hrbank.exception;
 import lombok.Getter;
 
 public enum ExceptionCode {
-    DEPARTMENT_HAS_EMPLOYEE_CANNOT_DELETE(400, "소속 직원이 있는 부서는 삭제할 수 없습니다.", "details"),
-    DEPARTMENT_ID_IS_NOT_FOUND(400, "잘못된 요청입니다.", "details"),
+    DEPARTMENT_HAS_EMPLOYEE_CANNOT_DELETE(400, "잘못된 요청입니다.", "소속 직원이 있는 부서는 삭제할 수 없습니다."),
+    DEPARTMENT_ID_IS_NOT_FOUND(404, "잘못된 요청입니다.", "해당 부서를 찾을 수 없습니다."),
     STORED_FILE_NOT_FOUND(404,"잘못된 요청입니다.","해당 이미지를 찾을 수 없습니다."),
-    EMAIL_ALREADY_EXISTS(400, "잘못된 요청입니다.", "해당 이메일은 이미 존재합니다."),
-    EMPLOYEE_NOT_FOUND(404, "잘못된 요청입니다.", "해당 직원을 찾을 수 없습니다."),
+    NAME_ALREADY_EXISTS(400, "잘못된 입력입니다.", "해당 이름은 이미 존재합니다."),
+    NAME_CANNOT_BE_NULL(400, "잘못된 입력입니다.", "이름이 비어있거나 null이 될 수 없습니다."),
+    DESCRIPTION_CANNOT_BE_NULL(400, "잘못된 입력입니다.", "설명이 비어있거나 null이 될 수 없습니다."),
+    EMAIL_ALREADY_EXISTS(400,"잘못된 입력입니다.","해당 이메일은 이미 존재합니다."),
+    EMPLOYEE_NOT_FOUND(404,"잘못된 요청입니다.", "해당 직원을 찾을 수 없습니다."),
     STOREDFILE_NOT_FOUND(404, "잘못된 요청입니다.", "해당 파일을 찾을 수 없습니다.");
 //    USER_NOT_FOUND(404, "User Not Found"),
 //    EMAIL_OR_USERNAME_ALREADY_EXISTS(400, "User With Email Already Exists"),


### PR DESCRIPTION
## 📌 PR 내용 요약
- 부서 수정 기능을 구현하였습니다.

- #49 에 적용된 `employeeCount`를 구해오는 로직이 적용되었습니다.

- `ExceptionCode`가 #47 과 동일합니다.

- 전역적으로 처리되던 `@Transactional`을 제거하고, 메서드 단위로 변경하였습니다.

## 🔗 관련 이슈
- Closes #15 

## 🙋 리뷰어에게 요청사항
- 리뷰해주신 부분은 #60 으로 반영됩니다.