### PR TITLE
feat(부서): 부서 상세 조회 기능 구현 

### DIFF
--- a/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
+++ b/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
@@ -1,16 +1,13 @@
 package com.codeit.hrbank.department.controller;
 
-import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
-import com.codeit.hrbank.department.dto.response.CursorPageResponseDepartmentDto;
 import com.codeit.hrbank.department.dto.response.DepartmentDto;
 import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.mapper.DepartmentMapper;
 import com.codeit.hrbank.department.service.DepartmentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,29 +19,10 @@ public class DepartmentController {
     private final DepartmentService departmentService;
     private final DepartmentMapper departmentMapper;
 
-    @GetMapping
-    public ResponseEntity<?> getAll(@ModelAttribute("departmentGetAllRequest") DepartmentGetAllRequest departmentGetAllRequest) {
-        Page<Department> departments = departmentService.getAllDepartments(departmentGetAllRequest);
-        if(!departments.hasContent() || departments.getContent().isEmpty()) {
-            return ResponseEntity.ok(CursorPageResponseDepartmentDto.from(Page.empty(), null, null));
-        }
-
-        Long idAfter = departments.getContent().get(departments.getContent().size() - 1).getId();
-
-        String cursor = null;
-        switch(departmentGetAllRequest.sortField()) {
-            case "name" -> {
-                cursor = departments.getContent().get(departments.getContent().size() - 1).getName();
-            }
-            case "establishedDate" -> {
-                cursor = departments.getContent().get(departments.getContent().size() - 1).getEstablishedDate().toString();
-            }
-        }
-
-        Page<DepartmentDto> departmentDtos = departments
-                .map(department -> departmentMapper.toDto(department, departmentService.getEmployeeCountByDepartmentId(department.getId())));
-
-        CursorPageResponseDepartmentDto response = CursorPageResponseDepartmentDto.from(departmentDtos, idAfter, cursor);
-        return ResponseEntity.ok(response);
+    @GetMapping("/{id}")
+    public ResponseEntity<?> get(@PathVariable Long id) {
+        Department department = departmentService.getDepartment(id);
+        DepartmentDto departmentDto = departmentMapper.toDto(department, departmentService.getEmployeeCountByDepartmentId(department.getId()));
+        return ResponseEntity.ok(departmentDto);
     }
 }

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -1,20 +1,13 @@
 package com.codeit.hrbank.department.service;
 
-import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
 import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.repository.DepartmentRepository;
-import com.codeit.hrbank.department.specification.DepartmentSpecification;
 import com.codeit.hrbank.employee.repository.EmployeeRepository;
+import com.codeit.hrbank.exception.BusinessLogicException;
+import com.codeit.hrbank.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -26,63 +19,9 @@ public class BasicDepartmentService implements DepartmentService {
     private final EmployeeRepository employeeRepository;
 
     @Override
-    public Page<Department> getAllDepartments(DepartmentGetAllRequest departmentGetAllRequest) {
-        // 검색 필드, 정렬 방향 초기화
-        String sortField = departmentGetAllRequest.sortField() == null || departmentGetAllRequest.sortField().isEmpty() ? "name" : departmentGetAllRequest.sortField();
-        String sortDirection = departmentGetAllRequest.sortDirection() == null ? "asc" : departmentGetAllRequest.sortDirection();
-
-        Specification<Department> spec = Specification.unrestricted();
-
-        // 정렬 방향 설정
-        if ("asc".equalsIgnoreCase(sortDirection)) {
-            switch (sortField) {
-                case "name" -> {
-                    spec = spec.and(DepartmentSpecification.greaterThanName(
-                            departmentGetAllRequest.idAfter(),
-                            departmentGetAllRequest.cursor())
-                    );
-                }
-                case "establishedDate" -> {
-                    spec = spec.and(DepartmentSpecification.greaterThanEstablishedDate(
-                            departmentGetAllRequest.idAfter(),
-                            LocalDate.parse(departmentGetAllRequest.cursor()))
-                    );
-                }
-            }
-        } else if ("desc".equalsIgnoreCase(sortDirection)) {
-            switch (sortField) {
-                case "name" -> {
-                    spec = spec.and(DepartmentSpecification.lessThanName(
-                            departmentGetAllRequest.idAfter(),
-                            departmentGetAllRequest.cursor())
-                    );
-                }
-                case "establishedDate" -> {
-                    spec = spec.and(DepartmentSpecification.lessThanEstablishedDate(
-                            departmentGetAllRequest.idAfter(),
-                            LocalDate.parse(departmentGetAllRequest.cursor()))
-                    );
-                }
-            }
-        }
-
-        // 검색 조건
-        spec = spec.and(DepartmentSpecification.likeName(departmentGetAllRequest.nameOrDescription()));
-        spec = spec.and(DepartmentSpecification.likeDescription(departmentGetAllRequest.nameOrDescription()));
-
-        // Pageable
-        Pageable pageable = null;
-        int pageSize = departmentGetAllRequest.size() == null ? 10 : departmentGetAllRequest.size();
-        switch(sortDirection.toLowerCase()) {
-            case "asc" -> {
-                pageable = PageRequest.ofSize(pageSize).withSort(Sort.by(sortField).ascending());
-            }
-            case "desc" -> {
-                pageable = PageRequest.ofSize(pageSize).withSort(Sort.by(sortField).descending());
-            }
-            default -> pageable = PageRequest.ofSize(pageSize).withSort(Sort.by(sortField).ascending());
-        }
-        return departmentRepository.findAll(spec, pageable);
+    public Department getDepartment(Long id) {
+        return departmentRepository.findById(id)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.DEPARTMENT_ID_IS_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -7,11 +7,9 @@ import com.codeit.hrbank.exception.BusinessLogicException;
 import com.codeit.hrbank.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class BasicDepartmentService implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;

--- a/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
@@ -1,11 +1,9 @@
 package com.codeit.hrbank.department.service;
 
-import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
 import com.codeit.hrbank.department.entity.Department;
-import org.springframework.data.domain.Page;
 
 public interface DepartmentService {
-    Page<Department> getAllDepartments(DepartmentGetAllRequest pageRequest);
+    Department getDepartment(Long id);
 
     Long getEmployeeCountByDepartmentId(Long departmentId);
 }

--- a/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
+++ b/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
@@ -3,11 +3,14 @@ package com.codeit.hrbank.exception;
 import lombok.Getter;
 
 public enum ExceptionCode {
-    DEPARTMENT_HAS_EMPLOYEE_CANNOT_DELETE(400, "소속 직원이 있는 부서는 삭제할 수 없습니다.", "details"),
-    DEPARTMENT_ID_IS_NOT_FOUND(400, "잘못된 요청입니다.", "details"),
+    DEPARTMENT_HAS_EMPLOYEE_CANNOT_DELETE(400, "잘못된 요청입니다.", "소속 직원이 있는 부서는 삭제할 수 없습니다."),
+    DEPARTMENT_ID_IS_NOT_FOUND(404, "잘못된 요청입니다.", "해당 부서를 찾을 수 없습니다."),
     STORED_FILE_NOT_FOUND(404,"잘못된 요청입니다.","해당 이미지를 찾을 수 없습니다."),
-    EMAIL_ALREADY_EXISTS(400, "잘못된 요청입니다.", "해당 이메일은 이미 존재합니다."),
-    EMPLOYEE_NOT_FOUND(404, "잘못된 요청입니다.", "해당 직원을 찾을 수 없습니다."),
+    NAME_ALREADY_EXISTS(400, "잘못된 입력입니다.", "해당 이름은 이미 존재합니다."),
+    NAME_CANNOT_BE_NULL(400, "잘못된 입력입니다.", "이름이 비어있거나 null이 될 수 없습니다."),
+    DESCRIPTION_CANNOT_BE_NULL(400, "잘못된 입력입니다.", "설명이 비어있거나 null이 될 수 없습니다."),
+    EMAIL_ALREADY_EXISTS(400,"잘못된 입력입니다.","해당 이메일은 이미 존재합니다."),
+    EMPLOYEE_NOT_FOUND(404,"잘못된 요청입니다.", "해당 직원을 찾을 수 없습니다."),
     STOREDFILE_NOT_FOUND(404, "잘못된 요청입니다.", "해당 파일을 찾을 수 없습니다.");
 //    USER_NOT_FOUND(404, "User Not Found"),
 //    EMAIL_OR_USERNAME_ALREADY_EXISTS(400, "User With Email Already Exists"),


### PR DESCRIPTION
## 📌 PR 내용 요약
- `@PathVariable`로 전달 받은 `id`값을 토대로 부서를 상세 조회합니다.

- #49 에서 사용된 `employeeCount`를 구하는 로직: `employeeRepository.countByDepartmentId`를 사용하였습니다.

- #47 에 추가된 것과 동일한 `ExceptionCode` 입니다.

- 단순 조회라서 `@Transactional` 처리를 제거하였습니다.

## 🔗 관련 이슈
- Closes #17 

## 🙋 리뷰어에게 요청사항
- 리뷰해주신 부분은 #60 으로 반영됩니다.