### PR TITLE
feat(부서): 부서 삭제 기능 구현 

### DIFF
--- a/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
+++ b/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
@@ -1,16 +1,11 @@
 package com.codeit.hrbank.department.controller;
 
-import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
-import com.codeit.hrbank.department.dto.response.CursorPageResponseDepartmentDto;
-import com.codeit.hrbank.department.dto.response.DepartmentDto;
-import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.mapper.DepartmentMapper;
 import com.codeit.hrbank.department.service.DepartmentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,29 +17,9 @@ public class DepartmentController {
     private final DepartmentService departmentService;
     private final DepartmentMapper departmentMapper;
 
-    @GetMapping
-    public ResponseEntity<?> getAll(@ModelAttribute("departmentGetAllRequest") DepartmentGetAllRequest departmentGetAllRequest) {
-        Page<Department> departments = departmentService.getAllDepartments(departmentGetAllRequest);
-        if(!departments.hasContent() || departments.getContent().isEmpty()) {
-            return ResponseEntity.ok(CursorPageResponseDepartmentDto.from(Page.empty(), null, null));
-        }
-
-        Long idAfter = departments.getContent().get(departments.getContent().size() - 1).getId();
-
-        String cursor = null;
-        switch(departmentGetAllRequest.sortField()) {
-            case "name" -> {
-                cursor = departments.getContent().get(departments.getContent().size() - 1).getName();
-            }
-            case "establishedDate" -> {
-                cursor = departments.getContent().get(departments.getContent().size() - 1).getEstablishedDate().toString();
-            }
-        }
-
-        Page<DepartmentDto> departmentDtos = departments
-                .map(department -> departmentMapper.toDto(department, departmentService.getEmployeeCountByDepartmentId(department.getId())));
-
-        CursorPageResponseDepartmentDto response = CursorPageResponseDepartmentDto.from(departmentDtos, idAfter, cursor);
-        return ResponseEntity.ok(response);
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id) {
+        departmentService.delete(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/codeit/hrbank/department/entity/Department.java
+++ b/src/main/java/com/codeit/hrbank/department/entity/Department.java
@@ -1,17 +1,14 @@
 package com.codeit.hrbank.department.entity;
 
 import com.codeit.hrbank.base_entity.BaseUpdatableEntity;
-import com.codeit.hrbank.employee.entity.Employee;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @Setter
@@ -27,7 +24,4 @@ public class Department extends BaseUpdatableEntity {
 
     @Column(nullable = false)
     private LocalDate establishedDate;
-
-    @OneToMany(mappedBy = "department")
-    private List<Employee> employees;
 }

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -1,5 +1,6 @@
 package com.codeit.hrbank.department.service;
 
+import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.repository.DepartmentRepository;
 import com.codeit.hrbank.employee.repository.EmployeeRepository;
 import com.codeit.hrbank.exception.BusinessLogicException;
@@ -19,9 +20,14 @@ public class BasicDepartmentService implements DepartmentService {
 
     @Override
     public void delete(Long id) {
-        if (!departmentRepository.existsById(id)) {
-            throw new BusinessLogicException(ExceptionCode.DEPARTMENT_ID_IS_NOT_FOUND);
+        Department department = departmentRepository.findById(id)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.DEPARTMENT_ID_IS_NOT_FOUND));
+
+        // 소속 직원이 있는 부서는 삭제 불가
+        if (getEmployeeCountByDepartmentId(department.getId()) > 0) {
+            throw new BusinessLogicException(ExceptionCode.DEPARTMENT_HAS_EMPLOYEE_CANNOT_DELETE);
         }
+
         departmentRepository.deleteById(id);
     }
 

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -1,20 +1,12 @@
 package com.codeit.hrbank.department.service;
 
-import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
-import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.repository.DepartmentRepository;
-import com.codeit.hrbank.department.specification.DepartmentSpecification;
 import com.codeit.hrbank.employee.repository.EmployeeRepository;
+import com.codeit.hrbank.exception.BusinessLogicException;
+import com.codeit.hrbank.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -26,64 +18,13 @@ public class BasicDepartmentService implements DepartmentService {
     private final EmployeeRepository employeeRepository;
 
     @Override
-    public Page<Department> getAllDepartments(DepartmentGetAllRequest departmentGetAllRequest) {
-        // 검색 필드, 정렬 방향 초기화
-        String sortField = departmentGetAllRequest.sortField() == null || departmentGetAllRequest.sortField().isEmpty() ? "name" : departmentGetAllRequest.sortField();
-        String sortDirection = departmentGetAllRequest.sortDirection() == null ? "asc" : departmentGetAllRequest.sortDirection();
-
-        Specification<Department> spec = Specification.unrestricted();
-
-        // 정렬 방향 설정
-        if ("asc".equalsIgnoreCase(sortDirection)) {
-            switch (sortField) {
-                case "name" -> {
-                    spec = spec.and(DepartmentSpecification.greaterThanName(
-                            departmentGetAllRequest.idAfter(),
-                            departmentGetAllRequest.cursor())
-                    );
-                }
-                case "establishedDate" -> {
-                    spec = spec.and(DepartmentSpecification.greaterThanEstablishedDate(
-                            departmentGetAllRequest.idAfter(),
-                            LocalDate.parse(departmentGetAllRequest.cursor()))
-                    );
-                }
-            }
-        } else if ("desc".equalsIgnoreCase(sortDirection)) {
-            switch (sortField) {
-                case "name" -> {
-                    spec = spec.and(DepartmentSpecification.lessThanName(
-                            departmentGetAllRequest.idAfter(),
-                            departmentGetAllRequest.cursor())
-                    );
-                }
-                case "establishedDate" -> {
-                    spec = spec.and(DepartmentSpecification.lessThanEstablishedDate(
-                            departmentGetAllRequest.idAfter(),
-                            LocalDate.parse(departmentGetAllRequest.cursor()))
-                    );
-                }
-            }
+    public void delete(Long id) {
+        if (!departmentRepository.existsById(id)) {
+            throw new BusinessLogicException(ExceptionCode.DEPARTMENT_ID_IS_NOT_FOUND);
         }
-
-        // 검색 조건
-        spec = spec.and(DepartmentSpecification.likeName(departmentGetAllRequest.nameOrDescription()));
-        spec = spec.and(DepartmentSpecification.likeDescription(departmentGetAllRequest.nameOrDescription()));
-
-        // Pageable
-        Pageable pageable = null;
-        int pageSize = departmentGetAllRequest.size() == null ? 10 : departmentGetAllRequest.size();
-        switch(sortDirection.toLowerCase()) {
-            case "asc" -> {
-                pageable = PageRequest.ofSize(pageSize).withSort(Sort.by(sortField).ascending());
-            }
-            case "desc" -> {
-                pageable = PageRequest.ofSize(pageSize).withSort(Sort.by(sortField).descending());
-            }
-            default -> pageable = PageRequest.ofSize(pageSize).withSort(Sort.by(sortField).ascending());
-        }
-        return departmentRepository.findAll(spec, pageable);
+        departmentRepository.deleteById(id);
     }
+
 
     @Override
     public Long getEmployeeCountByDepartmentId(Long departmentId) {

--- a/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
@@ -1,11 +1,7 @@
 package com.codeit.hrbank.department.service;
 
-import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
-import com.codeit.hrbank.department.entity.Department;
-import org.springframework.data.domain.Page;
-
 public interface DepartmentService {
-    Page<Department> getAllDepartments(DepartmentGetAllRequest pageRequest);
+    void delete(Long id);
 
     Long getEmployeeCountByDepartmentId(Long departmentId);
 }


### PR DESCRIPTION
## 📌 PR 내용 요약
- 부서 삭제 기능을 구현하였습니다.
- #49 에서 사용된 `employeeCount`를 구하는 로직을 적용하였습니다.
- #47 에서 추가된 `ExceptionCode`를 그대로 추가하였습니다.
- 소속 직원이 0명 이상인 부서는 삭제할 수 없습니다.

## 🔗 관련 이슈
- Closes #14 

## 🙋 리뷰어에게 요청사항
- 리뷰해주신 부분은 #60 으로 반영됩니다.