### PR TITLE
fix(직원, 부서): 동적 쿼리 로직 수정

### DIFF
--- a/src/main/java/com/codeit/hrbank/department/specification/DepartmentSpecification.java
+++ b/src/main/java/com/codeit/hrbank/department/specification/DepartmentSpecification.java
@@ -12,7 +12,9 @@ public class DepartmentSpecification {
     public static Specification<Department> likeName(String name) {
         return (root, query, criteriaBuilder) -> {
             if (name == null) return null;
-            return criteriaBuilder.like(root.get("name"), "%" + name.trim().toLowerCase() + "%");
+            return criteriaBuilder.like(
+                    criteriaBuilder.lower(criteriaBuilder.function("replace", String.class, root.get("name"), criteriaBuilder.literal(" "), criteriaBuilder.literal(""))),
+                    "%" + name.trim().toLowerCase().replaceAll("\\s+", "") + "%");
         };
     }
 
@@ -20,7 +22,9 @@ public class DepartmentSpecification {
     public static Specification<Department> likeDescription(String description) {
         return (root, query, criteriaBuilder) -> {
             if (description == null) return null;
-            return criteriaBuilder.like(root.get("description"), "%" + description.trim().toLowerCase() + "%");
+            return criteriaBuilder.like(
+                    criteriaBuilder.lower(criteriaBuilder.function("replace", String.class, root.get("description"), criteriaBuilder.literal(" "), criteriaBuilder.literal(""))),
+                    "%" + description.trim().toLowerCase().replaceAll("\\s+", "") + "%");
         };
     }
 

--- a/src/main/java/com/codeit/hrbank/department/specification/DepartmentSpecification.java
+++ b/src/main/java/com/codeit/hrbank/department/specification/DepartmentSpecification.java
@@ -3,6 +3,7 @@ package com.codeit.hrbank.department.specification;
 import com.codeit.hrbank.department.entity.Department;
 import jakarta.persistence.criteria.Predicate;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 
@@ -11,7 +12,7 @@ public class DepartmentSpecification {
     // 부분 일치 조건: 이름
     public static Specification<Department> likeName(String name) {
         return (root, query, criteriaBuilder) -> {
-            if (name == null) return null;
+            if (!StringUtils.hasText(name)) return null;
             return criteriaBuilder.like(
                     criteriaBuilder.lower(criteriaBuilder.function("replace", String.class, root.get("name"), criteriaBuilder.literal(" "), criteriaBuilder.literal(""))),
                     "%" + name.trim().toLowerCase().replaceAll("\\s+", "") + "%");
@@ -21,7 +22,7 @@ public class DepartmentSpecification {
     // 부분 일치 조건: 설명
     public static Specification<Department> likeDescription(String description) {
         return (root, query, criteriaBuilder) -> {
-            if (description == null) return null;
+            if (!StringUtils.hasText(description)) return null;
             return criteriaBuilder.like(
                     criteriaBuilder.lower(criteriaBuilder.function("replace", String.class, root.get("description"), criteriaBuilder.literal(" "), criteriaBuilder.literal(""))),
                     "%" + description.trim().toLowerCase().replaceAll("\\s+", "") + "%");

--- a/src/main/java/com/codeit/hrbank/employee/specification/EmployeeSpecification.java
+++ b/src/main/java/com/codeit/hrbank/employee/specification/EmployeeSpecification.java
@@ -7,6 +7,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 
@@ -16,8 +17,10 @@ public class EmployeeSpecification {
         return new Specification<Employee>() {
             @Override
             public Predicate toPredicate(Root<Employee> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
-                if (name == null) return null;
-                return criteriaBuilder.like(root.get("name"), "%" + name + "%");
+                if (!StringUtils.hasText(name)) return null;
+                return criteriaBuilder.like(
+                        criteriaBuilder.lower(criteriaBuilder.function("replace", String.class, root.get("name"), criteriaBuilder.literal(" "), criteriaBuilder.literal(""))),
+                        "%" + name.trim().toLowerCase().replaceAll("\\s+", "") + "%");
             }
         };
     }
@@ -26,8 +29,10 @@ public class EmployeeSpecification {
         return new Specification<Employee>() {
             @Override
             public Predicate toPredicate(Root<Employee> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
-                if (email == null) return null;
-                return criteriaBuilder.like(root.get("email"), "%" + email + "%");
+                if (!StringUtils.hasText(email)) return null;
+                return criteriaBuilder.like(
+                        criteriaBuilder.lower(criteriaBuilder.function("replace", String.class, root.get("email"), criteriaBuilder.literal(" "), criteriaBuilder.literal(""))),
+                        "%" + email.trim().toLowerCase().replaceAll("\\s+", "") + "%");
             }
         };
     }
@@ -36,8 +41,11 @@ public class EmployeeSpecification {
         return new Specification<Employee>() {
             @Override
             public Predicate toPredicate(Root<Employee> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
-                if (departmentName == null) return null;
-                return criteriaBuilder.like(root.get("department").get("name"), "%" + departmentName + "%");
+                if (!StringUtils.hasText(departmentName)) return null;
+
+                return criteriaBuilder.like(
+                        criteriaBuilder.lower(criteriaBuilder.function("replace", String.class, root.get("department").get("name"), criteriaBuilder.literal((" ")), criteriaBuilder.literal(""))),
+                        "%" + departmentName.trim().toLowerCase().replaceAll("\\s+", "") + "%");
             }
         };
     }
@@ -46,8 +54,10 @@ public class EmployeeSpecification {
         return new Specification<Employee>() {
             @Override
             public Predicate toPredicate(Root<Employee> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
-                if (position == null) return null;
-                return criteriaBuilder.like(root.get("position"), "%" + position + "%");
+                if (!StringUtils.hasText(position)) return null;
+                return criteriaBuilder.like(
+                        criteriaBuilder.lower(criteriaBuilder.function("replace", String.class, root.get("position"), criteriaBuilder.literal(" "), criteriaBuilder.literal(""))),
+                        "%" + position.trim().toLowerCase().replaceAll("\\s+", "") + "%");
             }
         };
     }
@@ -56,8 +66,10 @@ public class EmployeeSpecification {
         return new Specification<Employee>() {
             @Override
             public Predicate toPredicate(Root<Employee> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
-                if (employeeNumber == null) return null;
-                return criteriaBuilder.like(root.get("employeeNumber"), "%" + employeeNumber + "%");
+                if (!StringUtils.hasText(employeeNumber)) return null;
+                return criteriaBuilder.like(
+                        criteriaBuilder.lower(criteriaBuilder.function("replace", String.class, root.get("employeeNumber"), criteriaBuilder.literal(" "), criteriaBuilder.literal(""))),
+                        "%" + employeeNumber.trim().toLowerCase().replaceAll("\\s+", "") + "%");
             }
         };
     }

--- a/src/main/java/com/codeit/hrbank/event/handler/EmployeeChangeLogEventHandler.java
+++ b/src/main/java/com/codeit/hrbank/event/handler/EmployeeChangeLogEventHandler.java
@@ -14,6 +14,6 @@ public class EmployeeChangeLogEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(EmployeeLogEvent event){
-        changeLogService.create(event);
+        // changeLogService.create(event);
     }
 }

--- a/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
+++ b/src/main/java/com/codeit/hrbank/exception/ExceptionCode.java
@@ -11,7 +11,8 @@ public enum ExceptionCode {
     DESCRIPTION_CANNOT_BE_NULL(400, "잘못된 입력입니다.", "설명이 비어있거나 null이 될 수 없습니다."),
     EMAIL_ALREADY_EXISTS(400,"잘못된 입력입니다.","해당 이메일은 이미 존재합니다."),
     EMPLOYEE_NOT_FOUND(404,"잘못된 요청입니다.", "해당 직원을 찾을 수 없습니다."),
-    INVALID_DATE_FORMAT(400, "잘못된 요청입니다.", "날짜 형식이 잘못되었습니다.");
+    INVALID_DATE_FORMAT(400, "잘못된 요청입니다.", "날짜 형식이 잘못되었습니다."),
+    DEPARTMENT_CANNOT_BE_NULL(400, "잘못된 입력입니다.", "부서 id는 누락될 수 없습니다.");
 
 //    USER_NOT_FOUND(404, "User Not Found"),
 //    EMAIL_OR_USERNAME_ALREADY_EXISTS(400, "User With Email Already Exists"),


### PR DESCRIPTION
## 📌 PR 내용 요약
- `Employee`와 `Department`의 동적 쿼리 로직을 수정하였습니다.
  - 검색어가 공백과 대소문자에 영향 받지 않습니다.
  - 문자열에 대한 검사 로직을 `name == null`에서 `StringUtils.hasText(name)`으로 변경하였습니다.

- 직원 등록, 수정 서비스 로직을 변경하였습니다.
  -  빈 공백 값(`" "`)으로 업데이트 되는 문제를 수정하였습니다.
  - `findById`에서 객체(`Department`, `Employee`)를 찾지 못하면 예외를 던지도록 수정하였습니다.
  - `DEPARTMENT_CANNOT_BE_NULL` 예외 코드를 추가하여 직원 생성 시 부서 id가 `null`이면 해당 예외를 던집니다.

## 🔗 관련 이슈
- Closes #65 

## 🙋 리뷰어에게 요청사항 (선택)
- 민수님 파트인 직원에서 수정된 로직이 있어서, 리뷰를 꼭 부탁드리고 싶습니다.