### PR TITLE
fix(부서): 부서 목록 조회 N+1 문제 해결 

### DIFF
--- a/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
+++ b/src/main/java/com/codeit/hrbank/department/controller/DepartmentController.java
@@ -8,12 +8,17 @@ import com.codeit.hrbank.department.dto.response.DepartmentDto;
 import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.mapper.DepartmentMapper;
 import com.codeit.hrbank.department.service.DepartmentService;
+import com.codeit.hrbank.employee.projection.EmployeeCountByDepartmentProjection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RestController
@@ -38,8 +43,13 @@ public class DepartmentController {
             case "establishedDate" -> cursor = departments.getContent().get(departments.getContent().size() - 1).getEstablishedDate().toString();
         }
 
-        Page<DepartmentDto> page = departments
-                .map(department -> departmentMapper.toDto(department, departmentService.getEmployeeCountByDepartmentId(department.getId())));
+        List<Long> departmentIds = departments.getContent().stream().map(Department::getId).toList();
+        List<EmployeeCountByDepartmentProjection> projections = departmentService.getEmployeeCountsByDepartmentId(departmentIds);
+        Map<Long, Long> employeeCountMap = toEmployeeCountMap(projections);
+
+        Page<DepartmentDto> page = departments.map(department ->
+                departmentMapper.toDto(department, employeeCountMap.getOrDefault(department.getId(), 0L))
+        );
 
         CursorPageResponseDepartmentDto<DepartmentDto> response = CursorPageResponseDepartmentDto.from(page, idAfter, cursor);
         return ResponseEntity.ok(response);
@@ -58,7 +68,7 @@ public class DepartmentController {
 
     @PatchMapping("/{id}")
     public ResponseEntity update(@PathVariable("id") Long id,
-                                                @RequestBody DepartmentUpdateRequest departmentUpdateRequest) {
+                                 @RequestBody DepartmentUpdateRequest departmentUpdateRequest) {
         Department department = departmentService.update(departmentUpdateRequest, id);
         DepartmentDto response = departmentMapper.toDto(department, departmentService.getEmployeeCountByDepartmentId(department.getId()));
         return ResponseEntity.ok(response);
@@ -77,4 +87,11 @@ public class DepartmentController {
         return ResponseEntity.noContent().build();
     }
 
+    private Map<Long, Long> toEmployeeCountMap(List<EmployeeCountByDepartmentProjection> projections) {
+        return projections.stream()
+                .collect(Collectors.toMap(
+                        EmployeeCountByDepartmentProjection::getDepartmentId,
+                        EmployeeCountByDepartmentProjection::getEmployeeCount
+                ));
+    }
 }

--- a/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/BasicDepartmentService.java
@@ -5,6 +5,7 @@ import com.codeit.hrbank.department.dto.request.DepartmentUpdateRequest;
 import com.codeit.hrbank.department.entity.Department;
 import com.codeit.hrbank.department.repository.DepartmentRepository;
 import com.codeit.hrbank.department.specification.DepartmentSpecification;
+import com.codeit.hrbank.employee.projection.EmployeeCountByDepartmentProjection;
 import com.codeit.hrbank.employee.repository.EmployeeRepository;
 import com.codeit.hrbank.exception.BusinessLogicException;
 import com.codeit.hrbank.exception.ExceptionCode;
@@ -20,6 +21,7 @@ import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -112,7 +114,6 @@ public class BasicDepartmentService implements DepartmentService {
         Department department = getDepartment(id);
 
         // departmentUpdateRequest에 수정할 항목이 비어있으면 기존 값 유지
-
         String newName = StringUtils.hasText(departmentUpdateRequest.name()) ? departmentUpdateRequest.name() : department.getName();
 
         String newDescription = StringUtils.hasText(departmentUpdateRequest.description()) ? departmentUpdateRequest.description() : department.getDescription();
@@ -146,6 +147,13 @@ public class BasicDepartmentService implements DepartmentService {
         departmentRepository.delete(department);
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public List<EmployeeCountByDepartmentProjection> getEmployeeCountsByDepartmentId(List<Long> departmentIds) {
+        return employeeRepository.countEmployeeCountsByDepartmentIds(departmentIds);
+    }
+
+    @Transactional(readOnly = true)
     @Override
     public Long getEmployeeCountByDepartmentId(Long departmentId) {
         return employeeRepository.countByDepartmentId(departmentId);

--- a/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
+++ b/src/main/java/com/codeit/hrbank/department/service/DepartmentService.java
@@ -3,7 +3,10 @@ package com.codeit.hrbank.department.service;
 import com.codeit.hrbank.department.dto.request.DepartmentGetAllRequest;
 import com.codeit.hrbank.department.dto.request.DepartmentUpdateRequest;
 import com.codeit.hrbank.department.entity.Department;
+import com.codeit.hrbank.employee.projection.EmployeeCountByDepartmentProjection;
 import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 public interface DepartmentService {
     Page<Department> getAllDepartments(DepartmentGetAllRequest pageRequest);
@@ -17,4 +20,6 @@ public interface DepartmentService {
     void delete(Long id);
 
     Long getEmployeeCountByDepartmentId(Long departmentId);
+
+    List<EmployeeCountByDepartmentProjection> getEmployeeCountsByDepartmentId(List<Long> departmentId);
 }

--- a/src/main/java/com/codeit/hrbank/employee/projection/EmployeeCountByDepartmentProjection.java
+++ b/src/main/java/com/codeit/hrbank/employee/projection/EmployeeCountByDepartmentProjection.java
@@ -1,0 +1,6 @@
+package com.codeit.hrbank.employee.projection;
+
+public interface EmployeeCountByDepartmentProjection {
+    Long getDepartmentId();
+    Long getEmployeeCount();
+}

--- a/src/main/java/com/codeit/hrbank/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/codeit/hrbank/employee/repository/EmployeeRepository.java
@@ -2,6 +2,7 @@ package com.codeit.hrbank.employee.repository;
 
 import com.codeit.hrbank.employee.entity.Employee;
 import com.codeit.hrbank.employee.entity.EmployeeStatus;
+import com.codeit.hrbank.employee.projection.EmployeeCountByDepartmentProjection;
 import com.codeit.hrbank.employee.projection.EmployeeDistributionProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +19,7 @@ import java.util.Collection;
 import java.util.List;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long>, JpaSpecificationExecutor<Employee> {
-    @EntityGraph(attributePaths = {"department","profile"})
+    @EntityGraph(attributePaths = {"department", "profile"})
     @Override
     Page<Employee> findAll(Specification<Employee> spec, Pageable pageable);
 
@@ -63,4 +64,13 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>, JpaSp
             """)
     long countByHireDateInCurrentMonth(@Param("from") LocalDate from,
                                        @Param("to") LocalDate to);
+
+    @Query("""
+    SELECT e.department.id AS departmentId,
+            COUNT(e.id) AS employeeCount
+    FROM Employee e
+    WHERE e.department.id IN :departmentIds
+    GROUP BY e.department.id
+""")
+    List<EmployeeCountByDepartmentProjection> countEmployeeCountsByDepartmentIds(@Param("departmentIds") List<Long> departmentIds);
 }


### PR DESCRIPTION
## 📌 PR 내용 요약
- 부서 목록 조회 시 `N+1` 문제를 해결하였습니다.
  - `EmployeeRepository`에 직원 수 단건 조회 용, 다건 조회 용 메서드를 따로 추가하였습니다. 
    - 다건 조회 시에는 `EmployeeCountByDepartmentProjection` 클래스를 이용합니다. (새로 추가되었습니다)

  - 서비스 계층에서 직원 리포지터리에서 추가한 메서드의 결과 값을 반환합니다.
  - 컨트롤러 계층의 `getAll` 메서드 로직을 변경하였습니다.
    - `toEmployeeCountMap`: 서비스 계층에서 받아온 `EmployeeCountByDepartmentProjection`을 `Map<Long, Long>`형태로 변경합니다.

    - `Map`의 `Key` 값(`Long departmentId`)에 부합하면 그에 대한 `Value`(`Long employeeCount`)를 얻어 `DepartmentDto`로 매핑이 가능합니다. (`Map`안에 `Key`값이 없을 경우, `employeeCount`의 디폴트 값은 `0`)

## 🔗 관련 이슈
- Closes #76 

## 🙋 리뷰어에게 요청사항 (선택)
- Dto 구성을 위한 직원 수의 집계 로직만 필요하였고(연관 관계 매핑이 필요 없음), Dto로의 변환을 컨트롤러에서 수행해야 했기 때문에 로직이 복잡해진 것 같습니다. 

- 더 간단하게 구현할 수 있는 아이디어가 있으시면 리뷰 남겨주시면 감사하겠습니다.