### PR TITLE
fix(대시보드): 소수점 표기 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### localFile#
+localFile/

--- a/src/main/java/com/codeit/hrbank/employee/mapper/EmployeeMapper.java
+++ b/src/main/java/com/codeit/hrbank/employee/mapper/EmployeeMapper.java
@@ -3,7 +3,6 @@ package com.codeit.hrbank.employee.mapper;
 import com.codeit.hrbank.employee.dto.EmployeeDistributionDto;
 import com.codeit.hrbank.employee.dto.EmployeeDto;
 import com.codeit.hrbank.employee.dto.EmployeeTrendDto;
-import com.codeit.hrbank.employee.dto.request.EmployeeGetAllRequest;
 import com.codeit.hrbank.employee.entity.Employee;
 import com.codeit.hrbank.employee.projection.EmployeeDistributionProjection;
 import com.codeit.hrbank.employee.projection.EmployeeTrendProjection;
@@ -21,9 +20,7 @@ public interface EmployeeMapper {
     @Mapping(target = "profileImageId", expression = "java(employee.getProfile() != null ? employee.getProfile().getId() : null)")
     EmployeeDto toDto(Employee employee);
 
-    EmployeeGetAllRequest toGetAllRequest(EmployeeDto dto);
-
-    @Mapping(target = "percentage", expression = "java((double) projection.getCount() / employeeCount)")
+    @Mapping(target = "percentage", expression = "java(((double) (projection.getCount()) / employeeCount)*100.0)")
     EmployeeDistributionDto toEmployeeDistributionDto(EmployeeDistributionProjection projection, long employeeCount);
 
     default
@@ -42,7 +39,7 @@ public interface EmployeeMapper {
                     date,
                     currentCount,
                     change,
-                    changeRate
+                    changeRate*100.0
             );
 
             employeeTrendDtos.add(dto);


### PR DESCRIPTION
## 📌 PR 내용 요약
- 대시보드에서 소수점 표기가 `0.3`, `0.5` 등으로 표기되던 걸 `30%`, `50%`로 표기되도록 변경하였습니다.
- `.gitIgnore` 파일에 `/localFile`을 추가하였습니다.

## 🔗 관련 이슈
- Closes #80 