### PR TITLE
fix(대시보드): 직원 분포도 퍼센트 계산 로직 변경

### DIFF
--- a/src/main/java/com/codeit/hrbank/employee/mapper/EmployeeMapper.java
+++ b/src/main/java/com/codeit/hrbank/employee/mapper/EmployeeMapper.java
@@ -20,7 +20,7 @@ public interface EmployeeMapper {
     @Mapping(target = "profileImageId", expression = "java(employee.getProfile() != null ? employee.getProfile().getId() : null)")
     EmployeeDto toDto(Employee employee);
 
-    @Mapping(target = "percentage", expression = "java(((double) (projection.getCount()) / employeeCount)*100.0)")
+    @Mapping(target = "percentage", expression = "java(employeeCount == 0 ? 0.0 : ((double) projection.getCount() / employeeCount) * 100.0")
     EmployeeDistributionDto toEmployeeDistributionDto(EmployeeDistributionProjection projection, long employeeCount);
 
     default


### PR DESCRIPTION
## 📌 PR 내용 요약
- 분모가 0일 때에는 0으로 값이 들어갑니다.

## 🔗 관련 이슈
- Closes #86 


## 🙋 리뷰어에게 요청사항 (선택)
- 정적 리소스 부분(`application.yaml`)이 배포 전용으로 변경되어서, 정적 리소스에서는 테스트 하지 못했습니다.