### PR TITLE
fix(대시보드): 로직 변경

### DIFF
--- a/src/main/java/com/codeit/hrbank/employee/mapper/EmployeeMapper.java
+++ b/src/main/java/com/codeit/hrbank/employee/mapper/EmployeeMapper.java
@@ -32,8 +32,8 @@ public interface EmployeeMapper {
             long currentCount = projection.getCurrentCount();
             long prevCount = projection.getPrevCount();
 
-            long change = (prevCount == 0L) ? 0L : currentCount - prevCount;
-            double changeRate = (prevCount == 0L) ? 0.0 : (double) change / prevCount;
+            long change = currentCount - prevCount;
+            double changeRate = (prevCount == 0L) ? currentCount : (double) change / prevCount;
 
             EmployeeTrendDto dto = new EmployeeTrendDto(
                     date,

--- a/src/main/java/com/codeit/hrbank/employee/service/BasicEmployeeService.java
+++ b/src/main/java/com/codeit/hrbank/employee/service/BasicEmployeeService.java
@@ -216,7 +216,7 @@ public class BasicEmployeeService implements EmployeeService {
     @Override
     public Long getCount(EmployeeStatus status, LocalDate fromDate, LocalDate toDate) {
         if (fromDate == null) fromDate = LocalDate.of(1900, 1, 1);
-        if (toDate == null) toDate = LocalDate.now();
+        if (toDate == null) toDate = LocalDate.now().plusYears(200);
         if (status == null) return employeeRepository.countTotalEmployee();
         return employeeRepository.countByStatusAndHireDateBetween(status, fromDate, toDate);
     }
@@ -234,7 +234,6 @@ public class BasicEmployeeService implements EmployeeService {
     @Transactional(readOnly = true)
     @Override
     public List<EmployeeTrendProjection> getTrend(LocalDate from, LocalDate to, UnitType unit) {
-        if (to == null) to = LocalDate.now();
         HireDatePeriod targetPeriod = new HireDatePeriod(unit, from, to);
         var statuses = List.of(EmployeeStatus.ACTIVE, EmployeeStatus.ON_LEAVE);
         return getEmployeeTrendProjections(targetPeriod.getFrom(), targetPeriod.getTo(), statuses, unit);

--- a/src/main/java/com/codeit/hrbank/employee/utility/HireDatePeriod.java
+++ b/src/main/java/com/codeit/hrbank/employee/utility/HireDatePeriod.java
@@ -5,7 +5,6 @@ import com.codeit.hrbank.exception.BusinessLogicException;
 import com.codeit.hrbank.exception.ExceptionCode;
 import lombok.Getter;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 
@@ -24,24 +23,25 @@ public class HireDatePeriod {
         // 일: 초기화 없음, 주: 해당 주차 월요일, 월/분기/년: 해당 월의 1일/마지막일
         switch (unitType) {
             case DAY -> {
-                this.from = from != null ? from : to.minusDays(12);
-                this.to = to;
+                this.to = to != null ? to : LocalDate.now();
+                this.from = from != null ? from : this.to.minusDays(12);
             }
             case WEEK -> {
-                this.from = from != null ? from.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY)) : to.minusWeeks(12).with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY));
-                this.to = to;
+                this.to = to != null ? to : LocalDate.now();
+                this.from = from != null ? from : this.to.minusWeeks(12);
+
             }
             case MONTH -> {
-                this.from = from != null ? from.with(TemporalAdjusters.lastDayOfMonth()) : to.minusMonths(12).with(TemporalAdjusters.lastDayOfMonth());
-                this.to = to.with(TemporalAdjusters.lastDayOfMonth());
+                this.to = to != null ? to.with(TemporalAdjusters.lastDayOfMonth()) : LocalDate.now().with(TemporalAdjusters.lastDayOfMonth());
+                this.from = from != null ? from.with(TemporalAdjusters.lastDayOfMonth()) : this.to.minusMonths(12).with(TemporalAdjusters.lastDayOfMonth());
             }
             case QUARTER -> {
-                this.from = from != null ? from.with(TemporalAdjusters.lastDayOfMonth()) : to.minusMonths(12 * 3).with(TemporalAdjusters.lastDayOfMonth());
-                this.to = to.with(TemporalAdjusters.lastDayOfMonth());
+                this.to = to != null ? to.with(TemporalAdjusters.lastDayOfMonth()) : LocalDate.now().with(TemporalAdjusters.lastDayOfMonth());
+                this.from = from != null ? from.with(TemporalAdjusters.lastDayOfMonth()) : this.to.minusMonths(12 * 3).with(TemporalAdjusters.lastDayOfMonth());
             }
             case YEAR -> {
-                this.from = from != null ? from.with(TemporalAdjusters.lastDayOfYear()) : to.minusYears(12).with(TemporalAdjusters.lastDayOfYear());
-                this.to = to.with(TemporalAdjusters.lastDayOfYear());
+                this.to = to != null ? to.with(TemporalAdjusters.lastDayOfYear()) : LocalDate.now().with(TemporalAdjusters.lastDayOfYear());
+                this.from = from != null ? from.with(TemporalAdjusters.lastDayOfYear()) : this.to.minusYears(12).with(TemporalAdjusters.lastDayOfYear());
             }
             default -> {
                 throw new BusinessLogicException(ExceptionCode.INVALID_DATE_FORMAT);


### PR DESCRIPTION
## 📌 PR 내용 요약
- 미래 데이터에 대응 가능하도록 변경
- 0명에서 1명으로 증가했을 때 증감률이 0으로 고정되는 동작 수정

## 🔗 관련 이슈
- Closes #88 

## 🙋 리뷰어에게 요청사항 (선택)
- 분포 쪽은 정적 리소스 화면에서는 잘 나오는데, 배포 상태일 때는 또 비정상 작동이 있을 수 있습니다.