### PR TITLE
Fix(직원) : 직원 입사일 정렬 오류 수정

### DIFF
--- a/src/main/java/com/codeit/hrbank/employee/service/BasicEmployeeService.java
+++ b/src/main/java/com/codeit/hrbank/employee/service/BasicEmployeeService.java
@@ -56,7 +56,7 @@ public class BasicEmployeeService implements EmployeeService {
             if ("name".equals(sortField)) {
                 spec = spec.and(EmployeeSpecification.greaterThanName(employeeGetAllRequest.idAfter(),employeeGetAllRequest.cursor()));
             } else if ("hireDate".equals(sortField)) {
-                spec = spec.and(EmployeeSpecification.greaterThanHireDate(employeeGetAllRequest.idAfter(), LocalDate.parse(employeeGetAllRequest.cursor())));
+                spec = spec.and(EmployeeSpecification.greaterThanHireDate(employeeGetAllRequest.idAfter(), employeeGetAllRequest.cursor()));
             } else if ("employeeNumber".equals(sortField)) {
                 spec = spec.and(EmployeeSpecification.greaterThanEmployeeNumber(employeeGetAllRequest.idAfter(), employeeGetAllRequest.cursor()));
             }
@@ -64,7 +64,7 @@ public class BasicEmployeeService implements EmployeeService {
             if ("name".equals(sortField)) {
                 spec = spec.and(EmployeeSpecification.lessThanName(employeeGetAllRequest.idAfter(),employeeGetAllRequest.cursor()));
             } else if ("hireDate".equals(sortField)) {
-                spec = spec.and(EmployeeSpecification.lessThanHireDate(employeeGetAllRequest.idAfter(), LocalDate.parse(employeeGetAllRequest.cursor())));
+                spec = spec.and(EmployeeSpecification.lessThanHireDate(employeeGetAllRequest.idAfter(), employeeGetAllRequest.cursor()));
             } else if ("employeeNumber".equals(sortField)) {
                 spec = spec.and(EmployeeSpecification.lessThanEmployeeNumber(employeeGetAllRequest.idAfter(), employeeGetAllRequest.cursor()));
             }

--- a/src/main/java/com/codeit/hrbank/employee/specification/EmployeeSpecification.java
+++ b/src/main/java/com/codeit/hrbank/employee/specification/EmployeeSpecification.java
@@ -108,14 +108,15 @@ public class EmployeeSpecification {
         };
     }
 
-    public static Specification<Employee> greaterThanHireDate(Long idAfter, LocalDate cursor) {
+    public static Specification<Employee> greaterThanHireDate(Long idAfter, String cursor) {
         return new Specification<Employee>() {
             @Override
             public Predicate toPredicate(Root<Employee> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
                 if (idAfter == null || cursor == null) return null;
-                Predicate greaterThanName = criteriaBuilder.greaterThan(root.get("hireDate"), cursor);
+                LocalDate dateCursor = LocalDate.parse(cursor);
+                Predicate greaterThanName = criteriaBuilder.greaterThan(root.get("hireDate"), dateCursor);
                 Predicate sort = criteriaBuilder.and(
-                        criteriaBuilder.equal(root.get("hireDate"), cursor),
+                        criteriaBuilder.equal(root.get("hireDate"), dateCursor),
                         criteriaBuilder.greaterThan(root.get("id"), idAfter));
                 return criteriaBuilder.or(greaterThanName, sort);
             }
@@ -150,14 +151,15 @@ public class EmployeeSpecification {
         };
     }
 
-    public static Specification<Employee> lessThanHireDate(Long idAfter, LocalDate cursor) {
+    public static Specification<Employee> lessThanHireDate(Long idAfter, String cursor) {
         return new Specification<Employee>() {
             @Override
             public Predicate toPredicate(Root<Employee> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
                 if (idAfter == null || cursor == null) return null;
-                Predicate greaterThanName = criteriaBuilder.lessThan(root.get("hireDate"), cursor);
+                LocalDate dateCursor = LocalDate.parse(cursor);
+                Predicate greaterThanName = criteriaBuilder.lessThan(root.get("hireDate"), dateCursor);
                 Predicate sort = criteriaBuilder.and(
-                        criteriaBuilder.equal(root.get("hireDate"), cursor),
+                        criteriaBuilder.equal(root.get("hireDate"), dateCursor),
                         criteriaBuilder.lessThan(root.get("id"), idAfter));
                 return criteriaBuilder.or(greaterThanName, sort);
             }


### PR DESCRIPTION
## 📌 PR 내용 요약
- 입사일 기준 정렬 시 발생하는 오류 수정
- LocalDate.parse(employeeGetAllRequest.cursor()) 시 cursor가 null이면 발생하는 오류 수정

## 🔗 관련 이슈
- Closes #85 