### PR TITLE
refactor(대시보드): 데이터 증감률 부정확성 해결

### DIFF
--- a/src/main/java/com/codeit/hrbank/employee/service/BasicEmployeeService.java
+++ b/src/main/java/com/codeit/hrbank/employee/service/BasicEmployeeService.java
@@ -255,6 +255,7 @@ public class BasicEmployeeService implements EmployeeService {
 
         switch (unit) {
             case DAY -> {
+                prevCount = employeeRepository.countByTargetDate(from.minusDays(1), statuses);
                 for (LocalDate cur = from;
                      !cur.isAfter(to);
                      cur = cur.plusDays(1)) {
@@ -270,6 +271,7 @@ public class BasicEmployeeService implements EmployeeService {
                 }
             }
             case WEEK -> {
+                prevCount = employeeRepository.countByTargetDate(from.minusWeeks(1), statuses);
                 for (LocalDate cur = from;
                      !cur.isAfter(to);
                      cur = cur.plusWeeks(1)) {
@@ -285,6 +287,7 @@ public class BasicEmployeeService implements EmployeeService {
                 }
             }
             case MONTH -> {
+                prevCount = employeeRepository.countByTargetDate(from.minusMonths(1), statuses);
                 for (LocalDate cur = from;
                      !cur.isAfter(to); cur = cur.plusMonths(1)) {
                     long currentCount = employeeRepository.countByTargetDate(cur, statuses);
@@ -299,6 +302,7 @@ public class BasicEmployeeService implements EmployeeService {
                 }
             }
             case QUARTER -> {
+                prevCount = employeeRepository.countByTargetDate(from.minusMonths(3), statuses);
                 for (LocalDate cur = from;
                      !cur.isAfter(to);
                      cur = cur.plusMonths(3)) {
@@ -314,6 +318,7 @@ public class BasicEmployeeService implements EmployeeService {
                 }
             }
             case YEAR -> {
+                prevCount = employeeRepository.countByTargetDate(from.minusYears(1), statuses);
                 for (LocalDate cur = from;
                      !cur.isAfter(to);
                      cur = cur.plusYears(1)) {


### PR DESCRIPTION

## 📌 PR 내용 요약
- `prevCount`를 리포지터리에서 조회하는 방식으로 초기화하여 전날 대비 직원 수의 증감률 데이터의 정확도 향상

## 🔗 관련 이슈
- Closes #92 
